### PR TITLE
Force node down when masakari gets called on node down event

### DIFF
--- a/masakari-controller/controller/masakari_controller.py
+++ b/masakari-controller/controller/masakari_controller.py
@@ -154,6 +154,8 @@ class RecoveryController(object):
                                   False,))
                         th.start()
 
+                        # PF9 begin
+                        """
                         # Sleep until updating nova-compute service status
                         # down.
                         self.rc_util.syslogout_ex(
@@ -165,6 +167,10 @@ class RecoveryController(object):
                                "service status." % (node_err_wait))
                         self.rc_util.syslogout(msg, syslog.LOG_INFO)
                         greenthread.sleep(int(node_err_wait))
+                        """
+                        # Mark nova compute service as 'down' to immediately start evacuation
+                        self.rc_worker.mark_host_down_pf9(row.notification_hostname)
+                        # PF9 end
 
                         # Start add_failed_host thread
                         # TODO(sampath):
@@ -379,6 +385,8 @@ class RecoveryController(object):
                         th.start()
 
                         # Sleep until nova recognizes the node down.
+                        # PF9 begin
+                        """
                         self.rc_util.syslogout_ex(
                             "RecoveryController_0029", syslog.LOG_INFO)
                         dic = self.rc_config.get_value('recover_starter')
@@ -389,7 +397,11 @@ class RecoveryController(object):
                                )
                         self.rc_util.syslogout(msg, syslog.LOG_INFO)
                         greenthread.sleep(int(node_err_wait))
-
+                        """
+                        # PF9 shoot the service
+                        self.rc_worker.mark_host_down_pf9( notification_list_dic.get(
+                            "notification_hostname"))
+                        # PF9 end
                         retry_mode = False
                         th = threading.Thread(
                             target=self.rc_starter.add_failed_host,

--- a/masakari-controller/controller/masakari_worker.py
+++ b/masakari-controller/controller/masakari_worker.py
@@ -433,6 +433,26 @@ class RecoveryControllerWorker(object):
                 self.rc_util.syslogout(tb, syslog.LOG_ERR)
             return
 
+    def mark_host_down_pf9(self, hostname):
+        """
+        Mark host service state as 'down' in nova.
+        :param hostname:
+        :return:
+        """
+        try:
+            self.rc_util_api.force_host_down_pf9(hostname)
+        except:
+            self.rc_util.syslogout_ex("RecoveryControllerWorker_0032",
+                                      syslog.LOG_ERR)
+            error_type, error_value, traceback_ = sys.exc_info()
+            tb_list = traceback.format_tb(traceback_)
+            self.rc_util.syslogout(error_type, syslog.LOG_ERR)
+            self.rc_util.syslogout(error_value, syslog.LOG_ERR)
+            for tb in tb_list:
+                self.rc_util.syslogout(tb, syslog.LOG_ERR)
+            return
+
+
     def recovery_instance(self, uuid, primary_id, sem):
         """
            Execute VM recovery.


### PR DESCRIPTION
This change adds force function to set hypervisor compute service as down.
Masakari used to wait for 3 minutes for the same result. 
