### PR TITLE
Private/smanpathak/keystone auth masakari

### DIFF
--- a/masakari-controller/controller/masakari_app.py
+++ b/masakari-controller/controller/masakari_app.py
@@ -1,0 +1,28 @@
+#
+# Copyright (c) 2016, Platform9 Systems. All Rights Reserved
+#
+
+from masakari_controller import RecoveryController
+
+
+class MasakariApp(object):
+    def __init__(self):
+        self._rc = RecoveryController()
+        self._rc.masakari()
+
+    def __call__(self, environ, start_response):
+        return self._rc.call(environ, start_response)
+
+
+def app_factory(global_config):
+    return MasakariApp()
+
+
+def main():
+    from paste import httpserver
+    from paste.deploy import loadapp
+    httpserver.serve(loadapp('config:masakari-api-paste.ini', relative_to='/etc/masakari'),
+                     host='127.0.0.1', port='15868')
+
+if __name__ == "__main__":
+    main()

--- a/masakari-controller/controller/masakari_controller.py
+++ b/masakari-controller/controller/masakari_controller.py
@@ -213,11 +213,15 @@ class RecoveryController(object):
                 target=self.rc_starter.handle_pending_instances)
             th.start()
 
+            # PF9 move this to __call__ for wsgi-fy app
             # Start reciever process for notification
+            """
             conf_wsgi_dic = self.rc_config.get_value('wsgi')
             wsgi.server(
                 eventlet.listen(('', int(conf_wsgi_dic['server_port']))),
                 self._notification_reciever)
+            """
+            # PF9 end
         except exc.SQLAlchemyError:
             error_type, error_value, traceback_ = sys.exc_info()
             tb_list = traceback.format_tb(traceback_)
@@ -314,6 +318,16 @@ class RecoveryController(object):
                 row_cnt += 1
 
         return return_value
+
+    def call(self, environ, start_response):
+        """
+        PF9 wsgi entrypoint to app. This function converts Masakari controller to app
+        format prescribed by paste framework.
+        :param environ:
+        :param start_response:
+        :return:
+        """
+        return self._notification_reciever(environ, start_response)
 
     def _check_json_param(self, json_data):
         try:

--- a/masakari-controller/controller/masakari_controller.py
+++ b/masakari-controller/controller/masakari_controller.py
@@ -154,6 +154,8 @@ class RecoveryController(object):
                                   False,))
                         th.start()
 
+                        # PF9 begin
+                        """
                         # Sleep until updating nova-compute service status
                         # down.
                         self.rc_util.syslogout_ex(
@@ -165,6 +167,10 @@ class RecoveryController(object):
                                "service status." % (node_err_wait))
                         self.rc_util.syslogout(msg, syslog.LOG_INFO)
                         greenthread.sleep(int(node_err_wait))
+                        """
+                        # Mark nova compute service as 'down' to immediately start evacuation
+                        self.rc_worker.mark_host_down_pf9(row.notification_hostname)
+                        # PF9 end
 
                         # Start add_failed_host thread
                         # TODO(sampath):
@@ -379,6 +385,8 @@ class RecoveryController(object):
                         th.start()
 
                         # Sleep until nova recognizes the node down.
+                        # PF9 begin
+                        """
                         self.rc_util.syslogout_ex(
                             "RecoveryController_0029", syslog.LOG_INFO)
                         dic = self.rc_config.get_value('recover_starter')
@@ -389,7 +397,11 @@ class RecoveryController(object):
                                )
                         self.rc_util.syslogout(msg, syslog.LOG_INFO)
                         greenthread.sleep(int(node_err_wait))
-
+                        """
+                        # PF9 shoot the service
+                        self.rc_worker.mark_host_down_pf9( notification_list_dic.get(
+                            "notification_hostname"))
+                        # PF9 end
                         retry_mode = False
                         th = threading.Thread(
                             target=self.rc_starter.add_failed_host,

--- a/masakari-controller/controller/masakari_worker.py
+++ b/masakari-controller/controller/masakari_worker.py
@@ -433,6 +433,26 @@ class RecoveryControllerWorker(object):
                 self.rc_util.syslogout(tb, syslog.LOG_ERR)
             return
 
+    def mark_host_down_pf9(self, hostname):
+        """
+        Mark host service state as 'down' in nova.
+        :param hostname:
+        :return:
+        """
+        try:
+            self.rc_util_api.force_host_down_pf9(hostname)
+        except:
+            self.rc_util.syslogout_ex("RecoveryControllerWorker_0032",
+                                      syslog.LOG_ERR)
+            error_type, error_value, traceback_ = sys.exc_info()
+            tb_list = traceback.format_tb(traceback_)
+            self.rc_util.syslogout(error_type, syslog.LOG_ERR)
+            self.rc_util.syslogout(error_value, syslog.LOG_ERR)
+            for tb in tb_list:
+                self.rc_util.syslogout(tb, syslog.LOG_ERR)
+            return
+
+
     def recovery_instance(self, uuid, primary_id, sem):
         """
            Execute VM recovery.

--- a/masakari-controller/etc/masakari-api-paste.ini
+++ b/masakari-controller/etc/masakari-api-paste.ini
@@ -1,0 +1,13 @@
+[composite:main]
+use = egg:Paste#urlmap
+/: masakari
+
+[pipeline: masakari]
+pipeline = authtoken masakari_app
+
+[app:masakari_app]
+paste.app_factory = controller.masakari_app:app_factory
+
+[filter:authtoken]
+paste.filter_factory = keystonemiddleware.auth_token:filter_factory
+

--- a/masakari-controller/requirements.txt
+++ b/masakari-controller/requirements.txt
@@ -12,3 +12,6 @@ python-novaclient>=3.3.0
 python-keystoneclient>=2.3.1
 SQLAlchemy>=1.0.12
 SQLAlchemy-Utils>=0.32.0
+PasteDeploy
+paste
+keystonemiddleware

--- a/masakari-controller/rpmbuild/SPECS/pf9-masakari-controller.spec
+++ b/masakari-controller/rpmbuild/SPECS/pf9-masakari-controller.spec
@@ -55,7 +55,7 @@ install -p -m 664 etc/systemd/system/pf9-masakari-controller.service %{buildroot
 # config files
 install -d -m 755 %{buildroot}%{_sysconfdir}/%{project}
 install -p -m 640 -t %{buildroot}%{_sysconfdir}/%{project}/ \
-                     etc/*.conf
+                     etc/*.conf etc/*.ini
 
 
 # patch the #!python with the venv's python
@@ -102,6 +102,7 @@ install -d -m 755 %{buildroot}%{_localstatedir}/run/%{project}
 # /etc/project config files
 %dir %{_sysconfdir}/%{project}
 %config(noreplace) %attr(-, root, %{project}) %{_sysconfdir}/%{project}/*.conf
+%config(noreplace) %attr(-, root, %{project}) %{_sysconfdir}/%{project}/*.ini
 
 # /var/lib 
 %dir %attr(0755, %{project}, nobody) %{_sharedstatedir}/%{project}

--- a/masakari-controller/setup.cfg
+++ b/masakari-controller/setup.cfg
@@ -29,4 +29,4 @@ data_files =
 
 [entry_points]
 console_scripts =
-		masakari-controller = controller.masakari_controller:main
+		masakari-controller = controller.masakari_app:main


### PR DESCRIPTION
This change enables keystone auth for Masakari. Masakari on ntt repo is a simple wsgi server. To avoid too many code changes, I converted it to a paste app and added keystonemiddleware to paste pipeline.

I wasn't able to test it because authentication is failing when I pass X-Auth-Token in http request to masakari. Need feedback on
(1) how to feed keystone endpoint config to middleware
(2) how to set up logging  for middleware.
